### PR TITLE
Updated power query examples to use Personal Access Tokens in request…

### DIFF
--- a/retrieve-all-records-from-table.m
+++ b/retrieve-all-records-from-table.m
@@ -7,10 +7,10 @@ let Pagination = List.Skip(List.Generate( () => [Last_Key = "init", Counter=0],
    WebCall = try if [Counter]<1
    then
    Json.Document(Web.Contents("https://api.airtable.com",
-     [RelativePath="v0/"&BASE_ID&"/"&TABLE_ID"", Headers=[#"Authorization"="Bearer "&PERSONAL_ACCESS_TOKEN,#"Content-Type"="application/json"]]))
+     [RelativePath="v0/"&BASE_ID&"/"&TABLE_ID&"", Headers=[#"Authorization"="Bearer "&PERSONAL_ACCESS_TOKEN,#"Content-Type"="application/json"]]))
    else
    Json.Document(Web.Contents("https://api.airtable.com",
-     [RelativePath="v0/"&BASE_ID&"/"&TABLE_ID"", Headers=[#"Authorization"="Bearer "&PERSONAL_ACCESS_TOKEN,#"Content-Type"="application/json"]])),
+     [RelativePath="v0/"&BASE_ID&"/"&TABLE_ID&"", Headers=[#"Authorization"="Bearer "&PERSONAL_ACCESS_TOKEN,#"Content-Type"="application/json"]])),
    Counter = [Counter]+1
  ],
  each [WebCall]

--- a/retrieve-all-records-from-table.m
+++ b/retrieve-all-records-from-table.m
@@ -7,10 +7,10 @@ let Pagination = List.Skip(List.Generate( () => [Last_Key = "init", Counter=0],
    WebCall = try if [Counter]<1
    then
    Json.Document(Web.Contents("https://api.airtable.com",
-     [RelativePath="v0/"&BASE_ID&"/"&TABLE_ID&"?api_key="&API_KEY&""]))
+     [RelativePath="v0/"&BASE_ID&"/"&TABLE_ID"", Headers=[#"Authorization"="Bearer "&PERSONAL_ACCESS_TOKEN,#"Content-Type"="application/json"]]))
    else
    Json.Document(Web.Contents("https://api.airtable.com",
-     [RelativePath="v0/"&BASE_ID&"/"&TABLE_ID&"?api_key="&API_KEY&"&offset="&Last_Key&""])),
+     [RelativePath="v0/"&BASE_ID&"/"&TABLE_ID"", Headers=[#"Authorization"="Bearer "&PERSONAL_ACCESS_TOKEN,#"Content-Type"="application/json"]])),
    Counter = [Counter]+1
  ],
  each [WebCall]

--- a/retrieve-all-records-from-view.m
+++ b/retrieve-all-records-from-view.m
@@ -7,10 +7,10 @@ let Pagination = List.Skip(List.Generate( () => [Last_Key = "init", Counter=0],
    WebCall = try if [Counter]<1
    then
    Json.Document(Web.Contents("https://api.airtable.com",
-     [RelativePath="v0/"&BASE_ID&"/"&TABLE_ID&"?view="&VIEW_ID&"&api_key="&API_KEY&""]))
+     [RelativePath="v0/"&BASE_ID&"/"&TABLE_ID&"?view="&VIEW_ID&"", Headers=[#"Authorization"="Bearer "&PERSONAL_ACCESS_TOKEN,#"Content-Type"="application/json"]]))
    else
    Json.Document(Web.Contents("https://api.airtable.com",
-     [RelativePath="v0/"&BASE_ID&"/"&TABLE_ID&"?view="&VIEW_ID&"&api_key="&API_KEY&"&offset="&Last_Key&""])),
+     [RelativePath="v0/"&BASE_ID&"/"&TABLE_ID&"?view="&VIEW_ID&"&offset="&Last_Key&"", Headers=[#"Authorization"="Bearer "&PERSONAL_ACCESS_TOKEN,#"Content-Type"="application/json"]])),
    Counter = [Counter]+1
  ],
  each [WebCall]


### PR DESCRIPTION
… headers instead of API keys in what will be the deprecated url query parameter