### PR TITLE
Update Table & View PowerQueries to use RelativePath to support Power BI Server Refreshes

### DIFF
--- a/retrieve-all-records-from-table.m
+++ b/retrieve-all-records-from-table.m
@@ -6,9 +6,9 @@ let Pagination = List.Skip( List.Generate( () => [Page_Key = "init", Counter=0],
       [WebCall][Value][offset] otherwise null, // determine the LastKey for the next execution
     WebCall = try if [Counter]<1
     then 
-      Json.Document(Web.Contents("https://api.airtable.com/v0/"&BASE_ID&"/"&TABLE_ID,[Headers=[Authorization="Bearer "&PERSONAL_ACCESS_TOKEN]]))
+      Json.Document(Web.Contents("https://api.airtable.com",[RelativePath="v0/"&BASE_ID&"/"&TABLE_ID,Headers=[Authorization="Bearer "&PERSONAL_ACCESS_TOKEN]]))
     else 
-      Json.Document(Web.Contents("https://api.airtable.com/v0/"&BASE_ID&"/"&TABLE_ID&"?offset="&[WebCall][Value][offset] , [Headers=[Authorization="Bearer "&PERSONAL_ACCESS_TOKEN]])),// retrieve results per call
+      Json.Document(Web.Contents("https://api.airtable.com",[RelativePath="v0/"&BASE_ID&"/"&TABLE_ID&"?offset="&[WebCall][Value][offset], Headers=[Authorization="Bearer "&PERSONAL_ACCESS_TOKEN]])),// retrieve results per call
     Counter = [Counter]+1// internal counter
   ],
   each [WebCall]

--- a/retrieve-all-records-from-view.m
+++ b/retrieve-all-records-from-view.m
@@ -6,9 +6,9 @@ let Pagination = List.Skip( List.Generate( () => [Page_Key = "init", Counter=0],
       [WebCall][Value][offset] otherwise null, // determine the LastKey for the next execution
     WebCall = try if [Counter]<1
     then 
-      Json.Document(Web.Contents("https://api.airtable.com/v0/"&BASE_ID&"/"&TABLE_ID&"?view="&VIEW_ID,[Headers=[Authorization="Bearer "&PERSONAL_ACCESS_TOKEN]]))
+      Json.Document(Web.Contents("https://api.airtable.com",[RelativePath="v0/"&BASE_ID&"/"&TABLE_ID&"?view="&VIEW_ID, Headers=[Authorization="Bearer "&PERSONAL_ACCESS_TOKEN]]))
     else 
-      Json.Document(Web.Contents("https://api.airtable.com/v0/"&BASE_ID&"/"&TABLE_ID&"?view="&VIEW_ID&"&offset="&[WebCall][Value][offset] , [Headers=[Authorization="Bearer "&PERSONAL_ACCESS_TOKEN]])),// retrieve results per call
+      Json.Document(Web.Contents("https://api.airtable.com",[RelativePath="v0/"&BASE_ID&"/"&TABLE_ID&"?view="&VIEW_ID&"&offset="&[WebCall][Value][offset], Headers=[Authorization="Bearer "&PERSONAL_ACCESS_TOKEN]])),// retrieve results per call
     Counter = [Counter]+1// internal counter
   ],
   each [WebCall]


### PR DESCRIPTION
This PR updates both PowerQuery `.m` files to use [Web.Contents](https://learn.microsoft.com/en-us/powerquery-m/web-contents)' `RelativePath` option in order to support refreshes from Power BI Server.

These changes were tested using Microsoft's hosted version of Power BI on app.powerbi.com