### PR TITLE
Updating queries to expand record fields dynamically

### DIFF
--- a/retrieve-all-records-from-table.m
+++ b/retrieve-all-records-from-table.m
@@ -85,4 +85,4 @@ let
         )))
     )
 in
-    #"Expanded Record Fields";
+    #"Expanded Record Fields"

--- a/retrieve-all-records-from-table.m
+++ b/retrieve-all-records-from-table.m
@@ -1,40 +1,88 @@
-let Pagination = List.Skip( List.Generate( () => [Page_Key = "init", Counter=0], // Start Value
-  each [Page_Key] <> null, // Condition under which the next execution will happen
-  each [
-    Page_Key = try if [Counter]<1 then ""
-    else 
-      [WebCall][Value][offset] otherwise null, // determine the LastKey for the next execution
-    WebCall = try if [Counter]<1
-    then 
-      Json.Document(Web.Contents("https://api.airtable.com",[RelativePath="v0/"&BASE_ID&"/"&TABLE_ID,Headers=[Authorization="Bearer "&PERSONAL_ACCESS_TOKEN]]))
-    else 
-      Json.Document(Web.Contents("https://api.airtable.com",[RelativePath="v0/"&BASE_ID&"/"&TABLE_ID&"?offset="&[WebCall][Value][offset], Headers=[Authorization="Bearer "&PERSONAL_ACCESS_TOKEN]])),// retrieve results per call
-    Counter = [Counter]+1// internal counter
-  ],
-  each [WebCall]
-),1),
-   #"Converted to Table" = Table.FromList(
-     Pagination, Splitter.SplitByNothing(), null, null, ExtraValues.Error),
-   #"Expanded Column1" = Table.ExpandRecordColumn(
-     #"Converted to Table", "Column1", {"Value"}, {"Column1.Value"}),
-   #"Expanded Column1.Value" = Table.ExpandRecordColumn(
-     #"Expanded Column1", "Column1.Value", {"records"}, {"Column1.Value.records"}),
-   #"Expanded Column1.Value.records" = Table.ExpandListColumn(
-     #"Expanded Column1.Value", "Column1.Value.records"),
-   #"Expanded Column1.Value.records1" = Table.ExpandRecordColumn(
-     #"Expanded Column1.Value.records", "Column1.Value.records",
-     {"id", "fields", "createdTime"},
-     {"Column1.Value.records.id", "Column1.Value.records.fields", "Column1.Value.records.createdTime"}),
-   #"Renamed Columns" = Table.RenameColumns(
-     #"Expanded Column1.Value.records1",{{"Column1.Value.records.id", "_airtableRecordId"},
-     {"Column1.Value.records.createdTime", "_airtableRecordCreatedAt"},
-     {"Column1.Value.records.fields", "_airtableRecordFields"}}),
-   #"Reordered Columns" = Table.ReorderColumns(
-     #"Renamed Columns",
-     {"_airtableRecordId", "_airtableRecordCreatedAt", "_airtableRecordFields"}),
-   #"Expanded Record Fields" = Table.ExpandRecordColumn(
-     #"Reordered Columns", "_airtableRecordFields",
-     Record.FieldNames(#"Reordered Columns"{0}[_airtableRecordFields]),
-     Record.FieldNames(#"Reordered Columns"{0}[_airtableRecordFields]))
+let 
+    // Pagination Logic: This part handles pagination by making API calls to Airtable with different offsets to retrieve paginated data.
+    Pagination = List.Skip(
+        List.Generate(
+            () => [Page_Key = "init", Counter=0], // Initialize page key and counter
+            each [Page_Key] <> null, // Continue generating while Page_Key is not null
+            each [
+                Page_Key = try if [Counter] < 1 then "" else [WebCall][Value][offset] otherwise null, // Determine the next Page_Key
+                WebCall = try if [Counter] < 1 then
+                    // Initial API call without offset
+                    Json.Document(
+                        Web.Contents(
+                            "https://api.airtable.com",
+                            [
+                                RelativePath = "v0/" & BASE_ID & "/" & TABLE_ID,
+                                Headers = [Authorization = "Bearer " & PERSONAL_ACCESS_TOKEN]
+                            ]
+                        )
+                    )
+                else
+                    // Subsequent API calls with offset
+                    Json.Document(
+                        Web.Contents(
+                            "https://api.airtable.com",
+                            [
+                                RelativePath = "v0/" & BASE_ID & "/" & TABLE_ID & "?offset=" & [WebCall][Value][offset],
+                                Headers = [Authorization = "Bearer " & PERSONAL_ACCESS_TOKEN]
+                            ]
+                        )
+                    ),
+                Counter = [Counter] + 1 // Increment the counter for each iteration
+            ],
+            each [WebCall]
+        ),
+        1
+    ),
+
+    // Convert the paginated data into a table
+    #"Converted to Table" = Table.FromList(
+        Pagination, Splitter.SplitByNothing(), null, null, ExtraValues.Error
+    ),
+
+    // Expand and structure the paginated data
+    #"Expanded Column1" = Table.ExpandRecordColumn(
+        #"Converted to Table", "Column1", {"Value"}, {"Column1.Value"}
+    ),
+    #"Expanded Column1.Value" = Table.ExpandRecordColumn(
+        #"Expanded Column1", "Column1.Value", {"records"}, {"Column1.Value.records"}
+    ),
+    #"Expanded Column1.Value.records" = Table.ExpandListColumn(
+        #"Expanded Column1.Value", "Column1.Value.records"
+    ),
+    #"Expanded Column1.Value.records1" = Table.ExpandRecordColumn(
+        #"Expanded Column1.Value.records", "Column1.Value.records",
+        {"id", "fields", "createdTime"},
+        {"Column1.Value.records.id", "Column1.Value.records.fields", "Column1.Value.records.createdTime"}
+    ),
+
+    // Rename columns to align with a specific naming convention.
+    #"Renamed Columns" = Table.RenameColumns(
+        #"Expanded Column1.Value.records1",
+        {
+            {"Column1.Value.records.id", "_airtableRecordId"},
+            {"Column1.Value.records.createdTime", "_airtableRecordCreatedAt"},
+            {"Column1.Value.records.fields", "_airtableRecordFields"}
+        }
+    ),
+
+    // Reorder columns to the desired order.
+    #"Reordered Columns" = Table.ReorderColumns(
+        #"Renamed Columns",
+        {"_airtableRecordId", "_airtableRecordCreatedAt", "_airtableRecordFields"}
+    ),
+
+    // Expand the record fields dynamically based on distinct field names, ensuring that all fields are expanded regardless of schema changes.
+    #"Expanded Record Fields" = Table.ExpandRecordColumn(
+        #"Reordered Columns", "_airtableRecordFields",
+        List.Distinct(List.Combine(List.Transform(
+            List.Transform(Table.ToRecords(#"Reordered Columns"), each Record.Field(_, "_airtableRecordFields")),
+            each Record.FieldNames(_)
+        ))),
+        List.Distinct(List.Combine(List.Transform(
+            List.Transform(Table.ToRecords(#"Reordered Columns"), each Record.Field(_, "_airtableRecordFields")),
+            each Record.FieldNames(_)
+        )))
+    )
 in
-    #"Expanded Record Fields"
+    #"Expanded Record Fields";

--- a/retrieve-all-records-from-view.m
+++ b/retrieve-all-records-from-view.m
@@ -85,5 +85,5 @@ let
         )))
     )
 in
-    #"Expanded Record Fields";
+    #"Expanded Record Fields"
 

--- a/retrieve-all-records-from-view.m
+++ b/retrieve-all-records-from-view.m
@@ -1,40 +1,89 @@
-let Pagination = List.Skip( List.Generate( () => [Page_Key = "init", Counter=0], // Start Value
-  each [Page_Key] <> null, // Condition under which the next execution will happen
-  each [
-    Page_Key = try if [Counter]<1 then ""
-    else 
-      [WebCall][Value][offset] otherwise null, // determine the LastKey for the next execution
-    WebCall = try if [Counter]<1
-    then 
-      Json.Document(Web.Contents("https://api.airtable.com",[RelativePath="v0/"&BASE_ID&"/"&TABLE_ID&"?view="&VIEW_ID, Headers=[Authorization="Bearer "&PERSONAL_ACCESS_TOKEN]]))
-    else 
-      Json.Document(Web.Contents("https://api.airtable.com",[RelativePath="v0/"&BASE_ID&"/"&TABLE_ID&"?view="&VIEW_ID&"&offset="&[WebCall][Value][offset], Headers=[Authorization="Bearer "&PERSONAL_ACCESS_TOKEN]])),// retrieve results per call
-    Counter = [Counter]+1// internal counter
-  ],
-  each [WebCall]
-),1),
-   #"Converted to Table" = Table.FromList(
-     Pagination, Splitter.SplitByNothing(), null, null, ExtraValues.Error),
-   #"Expanded Column1" = Table.ExpandRecordColumn(
-     #"Converted to Table", "Column1", {"Value"}, {"Column1.Value"}),
-   #"Expanded Column1.Value" = Table.ExpandRecordColumn(
-     #"Expanded Column1", "Column1.Value", {"records"}, {"Column1.Value.records"}),
-   #"Expanded Column1.Value.records" = Table.ExpandListColumn(
-     #"Expanded Column1.Value", "Column1.Value.records"),
-   #"Expanded Column1.Value.records1" = Table.ExpandRecordColumn(
-     #"Expanded Column1.Value.records", "Column1.Value.records",
-     {"id", "fields", "createdTime"},
-     {"Column1.Value.records.id", "Column1.Value.records.fields", "Column1.Value.records.createdTime"}),
-   #"Renamed Columns" = Table.RenameColumns(
-     #"Expanded Column1.Value.records1",{{"Column1.Value.records.id", "_airtableRecordId"},
-     {"Column1.Value.records.createdTime", "_airtableRecordCreatedAt"},
-     {"Column1.Value.records.fields", "_airtableRecordFields"}}),
-   #"Reordered Columns" = Table.ReorderColumns(
-     #"Renamed Columns",
-     {"_airtableRecordId", "_airtableRecordCreatedAt", "_airtableRecordFields"}),
-   #"Expanded Record Fields" = Table.ExpandRecordColumn(
-     #"Reordered Columns", "_airtableRecordFields",
-     Record.FieldNames(#"Reordered Columns"{0}[_airtableRecordFields]),
-     Record.FieldNames(#"Reordered Columns"{0}[_airtableRecordFields]))
+let 
+    // Pagination Logic: This part handles pagination by making API calls to Airtable with different offsets to retrieve paginated data.
+    Pagination = List.Skip(
+        List.Generate(
+            () => [Page_Key = "init", Counter=0], // Initialize page key and counter
+            each [Page_Key] <> null, // Continue generating while Page_Key is not null
+            each [
+                Page_Key = try if [Counter] < 1 then "" else [WebCall][Value][offset] otherwise null, // Determine the next Page_Key
+                WebCall = try if [Counter] < 1 then
+                    // Initial API call without offset
+                    Json.Document(
+                        Web.Contents(
+                            "https://api.airtable.com",
+                            [
+                                RelativePath = "v0/" & BASE_ID & "/" & TABLE_ID & "?view=" & VIEW_ID,
+                                Headers = [Authorization = "Bearer " & PERSONAL_ACCESS_TOKEN]
+                            ]
+                        )
+                    )
+                else
+                    // Subsequent API calls with offset
+                    Json.Document(
+                        Web.Contents(
+                            "https://api.airtable.com",
+                            [
+                                RelativePath = "v0/" & BASE_ID & "/" & TABLE_ID & "?view=" & VIEW_ID & "&offset=" & [WebCall][Value][offset],
+                                Headers = [Authorization = "Bearer " & PERSONAL_ACCESS_TOKEN]
+                            ]
+                        )
+                    ),
+                Counter = [Counter] + 1 // Increment the counter for each iteration
+            ],
+            each [WebCall]
+        ),
+        1
+    ),
+
+    // Convert the paginated data into a table
+    #"Converted to Table" = Table.FromList(
+        Pagination, Splitter.SplitByNothing(), null, null, ExtraValues.Error
+    ),
+
+    // Expand and structure the paginated data
+    #"Expanded Column1" = Table.ExpandRecordColumn(
+        #"Converted to Table", "Column1", {"Value"}, {"Column1.Value"}
+    ),
+    #"Expanded Column1.Value" = Table.ExpandRecordColumn(
+        #"Expanded Column1", "Column1.Value", {"records"}, {"Column1.Value.records"}
+    ),
+    #"Expanded Column1.Value.records" = Table.ExpandListColumn(
+        #"Expanded Column1.Value", "Column1.Value.records"
+    ),
+    #"Expanded Column1.Value.records1" = Table.ExpandRecordColumn(
+        #"Expanded Column1.Value.records", "Column1.Value.records",
+        {"id", "fields", "createdTime"},
+        {"Column1.Value.records.id", "Column1.Value.records.fields", "Column1.Value.records.createdTime"}
+    ),
+
+    // Rename columns to align with a specific naming convention.
+    #"Renamed Columns" = Table.RenameColumns(
+        #"Expanded Column1.Value.records1",
+        {
+            {"Column1.Value.records.id", "_airtableRecordId"},
+            {"Column1.Value.records.createdTime", "_airtableRecordCreatedAt"},
+            {"Column1.Value.records.fields", "_airtableRecordFields"}
+        }
+    ),
+
+    // Reorder columns to the desired order.
+    #"Reordered Columns" = Table.ReorderColumns(
+        #"Renamed Columns",
+        {"_airtableRecordId", "_airtableRecordCreatedAt", "_airtableRecordFields"}
+    ),
+
+    // Expand the record fields dynamically based on distinct field names, ensuring that all fields are expanded regardless of schema changes.
+    #"Expanded Record Fields" = Table.ExpandRecordColumn(
+        #"Reordered Columns", "_airtableRecordFields",
+        List.Distinct(List.Combine(List.Transform(
+            List.Transform(Table.ToRecords(#"Reordered Columns"), each Record.Field(_, "_airtableRecordFields")),
+            each Record.FieldNames(_)
+        ))),
+        List.Distinct(List.Combine(List.Transform(
+            List.Transform(Table.ToRecords(#"Reordered Columns"), each Record.Field(_, "_airtableRecordFields")),
+            each Record.FieldNames(_)
+        )))
+    )
 in
-    #"Expanded Record Fields"
+    #"Expanded Record Fields";
+


### PR DESCRIPTION
This PR fixes #8 to dynamically build the columns based on all of the fields in the records list returned from the Airtable API.

Credit goes to [this post](https://community.airtable.com/t5/other-questions/not-all-table-columns-loaded-to-power-bi/m-p/152880/highlight/true#M47625) in the community for the updated logic to support this.

Context:
By default the Airtable API does not return a given field in the record object if the field has no value.

This query will dynamically build the columns based on all fields detected in the records list. This results in all columns being displayed in PowerBi, even if the value for the field in the first record is null.

<img width="1413" alt="Screenshot 2023-11-01 at 11 30 43 AM" src="https://github.com/Airtable-Labs/msft-power-query-m-language/assets/15098939/d3e302fe-e54c-4ad3-8488-f32de3604a1e">
